### PR TITLE
Integrate File System to abstract the implementation of OS level rigid operation

### DIFF
--- a/goEtcd/api/models/records.go
+++ b/goEtcd/api/models/records.go
@@ -64,29 +64,9 @@ func (r *InMemory) Delete(key string) error {
 
 type Disk struct {
 	FS  afero.Fs
-	Key string `json:"key"`
-	Val string `json:"val"`
 }
 
-// type OpenFileFS interface {
-// 	fs.FS
-// 	OpenFile(name string, flag int, perm os.FileMode) (fs.File, error)
-// }
-
-// func OpenFile(fsys fs.FS, name string, flag int, perm os.FileMode) (fs.File, error) {
-// 	if fsys, ok := fsys.(OpenFileFS); ok {
-// 		return fsys.OpenFile(name, flag, perm)
-// 	}
-// 	if flag == os.O_RDONLY {
-// 		return fsys.Open(name)
-// 	}
-// 	return nil, fmt.Errorf("open %s: Operation not supported", name)
-// }
-
-// func Create(fsys fs.FS, name string) (fs.File, error) {
-// 	return OpenFile(fsys, name, os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0666)
-// }
-
+// Return the Disk structure file system
 func NewDisk() *Disk {
 	diskFs := afero.NewBasePathFs(afero.NewOsFs(), "storage")
 	ok, err := afero.DirExists(diskFs, "")
@@ -102,6 +82,7 @@ func NewDisk() *Disk {
 	return &Disk{FS: diskFs}
 }
 
+// Store key, value in the file system
 func (d *Disk) Store(key, val string) {
 	file, err := d.FS.Create(key)
 	if err != nil {

--- a/goEtcd/api/models/records_test.go
+++ b/goEtcd/api/models/records_test.go
@@ -1,0 +1,136 @@
+package models
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/spf13/afero"
+)
+
+func TestInMemory(t *testing.T) {
+	t.Run("Store", func(t *testing.T) {
+		cache := NewCache()
+		cache.Store("Aniruddha", "Basak")
+
+		if _, ok := cache.Data["Aniruddha"]; !ok {
+			t.Errorf("func -> %v | Data not being inserted", t.Name())
+		}
+	})
+
+	t.Run("List", func(t *testing.T) {
+		cache := NewCache()
+		cache.Store("Aniruddha", "Basak")
+		cache.Store("Golang", "Etcd")
+
+		want := map[string]string{
+			"Aniruddha": "Basak",
+			"Golang":    "Etcd",
+		}
+		got := cache.List()
+
+		if !reflect.DeepEqual(want, got) {
+			t.Errorf("func -> %v | Data not Listed properly", t.Name())
+		}
+	})
+
+	t.Run("Get", func(t *testing.T) {
+		cache := NewCache()
+		cache.Store("Aniruddha", "Basak")
+
+		_, err := cache.Get("Golang")
+		if err == nil {
+			t.Errorf("func -> %v | Should get key not found error", t.Name())
+		}
+
+		got, _ := cache.Get("Aniruddha")
+		if !reflect.DeepEqual(got, "Basak") {
+			t.Errorf("func -> %v | Value not getting", t.Name())
+		}
+	})
+
+	t.Run("Delete", func(t *testing.T) {
+		cache := NewCache()
+		cache.Store("Aniruddha", "Basak")
+
+		cache.Delete("Aniruddha")
+
+		_, err := cache.Get("Aniruddha")
+		if err == nil {
+			t.Errorf("func -> %v | Should get key not found error", t.Name())
+		}
+	})
+}
+
+func TestDisk(t *testing.T) {
+	t.Run("Store", func(t *testing.T) {
+		disk := GetMemDisk()
+		key, val := "file", "system"
+		disk.Store(key, val)
+
+		if ok, _ := afero.Exists(disk.FS, key); !ok {
+			t.Error("Failed to create file")
+		}
+
+		file, err := afero.ReadFile(disk.FS, key)
+		if err != nil {
+			t.Errorf("Couldn't read file : %v", err)
+		}
+
+		if !reflect.DeepEqual(string(file), val) {
+			t.Error("Couldn't write into the file")
+		}
+	})
+
+	t.Run("List", func(t *testing.T) {
+		disk := GetMemDisk()
+		want := map[string]string{
+			"file": "system",
+			"data": "structure",
+		}
+
+		for k, v := range want {
+			disk.Store(k, v)
+		}
+
+		got := disk.List()
+
+		if !reflect.DeepEqual(want, got) {
+			t.Error("Data not Listed properly")
+		}
+	})
+
+	t.Run("Get", func(t *testing.T) {
+		key, val := "file", "system"
+		disk := GetMemDisk()
+		disk.Store(key, val)
+
+		_, err := disk.Get("Golang")
+		if err == nil {
+			t.Error("Should get key not found error")
+		}
+
+		got, _ := disk.Get(key)
+
+		if !reflect.DeepEqual(val, got) {
+			t.Error("not getting the value")
+		}
+	})
+
+	t.Run("Delete", func(t *testing.T) {
+		key, val := "file", "system"
+		disk := GetMemDisk()
+		disk.Store(key, val)
+
+		disk.Delete(key)
+
+		_, err := disk.Get(key)
+		if err == nil {
+			t.Error("File should have been deleted")
+		}
+	})
+}
+
+func GetMemDisk() *Disk {
+	test_fs := afero.NewMemMapFs()
+	return &Disk{FS: test_fs}
+}


### PR DESCRIPTION
# Integrate File System abstraction

io/fs package only supports readonly file system so I got to know afero
package and give it a try. Still there are lot of hard coding which is
needed to be removed.

Refs :
- https://pkg.go.dev/github.com/spf13/afero
- https://pkg.go.dev/io/fs

TODO:

- Implement the file system abstraction.
- Write unit tests for all the operation using mock file system.

Signed-off-by: Aniruddha Basak <codewithaniruddha@gmail.com>